### PR TITLE
Updating app.js to remove .address from plugin references.

### DIFF
--- a/native-app/app/app.js
+++ b/native-app/app/app.js
@@ -1,14 +1,14 @@
 require([
     'astro',
     'bluebird',
-    'plugins/applicationPlugin',
+    'application',
     'plugins/webViewPlugin',
     'plugins/anchoredLayoutPlugin'
 ],
 function(
     Astro,
     Promise,
-    ApplicationPlugin,
+    Application,
     WebViewPlugin,
     AnchoredLayoutPlugin
 ) {
@@ -17,7 +17,6 @@ function(
     var BASE_URL = 'http://<Your IP Address>:5000/';
 
     // Initialize plugins
-    var applicationPromise = ApplicationPlugin.init();
     var mainWebViewPromise = WebViewPlugin.init();
     var layoutPromise = AnchoredLayoutPlugin.init();
 
@@ -32,12 +31,12 @@ function(
     });
 
     // Route all unhandled key presses to mainWebView
-    Promise.join(applicationPromise, mainWebViewPromise, function(application, mainWebView){
-        application.setMainInputPlugin(mainWebView);
+    mainWebViewPromise.then(function(mainWebView) {
+        Application.setMainInputPlugin(mainWebView);
     });
 
-    Promise.join(applicationPromise, layoutPromise, function(application, layout) {
-        application.setMainViewPlugin(layout);
+    layoutPromise.then(function(layout) {
+        Application.setMainViewPlugin(layout);
     });
 
 }, undefined, true);

--- a/native-app/app/config.js
+++ b/native-app/app/config.js
@@ -2,6 +2,7 @@ require.config({
     baseUrl: '.',
     paths: {
         'astro': '../node_modules/astro-sdk/js/src/astro',
+        'application': '../node_modules/astro-sdk/js/src/application',
         'bluebird': 'node_modules/bluebird/js/browser/bluebird',
         'plugin-manager': '../node_modules/astro-sdk/js/src/plugin-manager',
         'plugins': '../node_modules/astro-sdk/js/src/plugins',

--- a/native-app/scaffold/src/main/java/com/mobify/astro/scaffold/MainActivity.java
+++ b/native-app/scaffold/src/main/java/com/mobify/astro/scaffold/MainActivity.java
@@ -3,23 +3,22 @@ package com.mobify.astro.scaffold;
 import android.os.Bundle;
 
 import com.mobify.astro.AstroActivity;
-import com.mobify.astro.plugins.AnchoredLayoutPlugin;
 import com.mobify.astro.plugins.AnimationPlugin;
-import com.mobify.astro.plugins.ApplicationPlugin;
-import com.mobify.astro.plugins.AstroWorkerPlugin;
-import com.mobify.astro.plugins.DeviceNetworkPlugin;
-import com.mobify.astro.plugins.DrawerPlugin;
-import com.mobify.astro.plugins.HeaderBarPlugin;
-import com.mobify.astro.plugins.ImageViewPlugin;
-import com.mobify.astro.plugins.ModalViewPlugin;
+import com.mobify.astro.plugins.AnchoredLayoutPlugin;
+import com.mobify.astro.plugins.AstroWorker;
 import com.mobify.astro.plugins.loaders.DefaultLoaderPlugin;
 import com.mobify.astro.plugins.loaders.FourDotsLoaderPlugin;
+import com.mobify.astro.plugins.ImageViewPlugin;
+import com.mobify.astro.plugins.HeaderBarPlugin;
+import com.mobify.astro.plugins.ModalViewPlugin;
 import com.mobify.astro.plugins.webviewplugin.WebViewPlugin;
+import com.mobify.astro.plugins.DeviceNetworkPlugin;
+import com.mobify.astro.plugins.DrawerPlugin;
 
 import org.apache.cordova.CordovaWebView;
 
 public class MainActivity extends AstroActivity {
-    protected AstroWorkerPlugin worker;
+    protected AstroWorker worker;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -27,26 +26,19 @@ public class MainActivity extends AstroActivity {
 
         // Register plugins.
         // TODO: In the future we probably want to load this from a configuration file.
-        pluginManager.register(AstroWorkerPlugin.class);
-        pluginManager.register(ApplicationPlugin.class);
-
+        pluginManager.register(DeviceNetworkPlugin.class);
+        pluginManager.register(DrawerPlugin.class);
         pluginManager.register(WebViewPlugin.class);
-        // `DefaultLoaderPlugin` is the default spinner used by `WebViewPlugin`.
+        pluginManager.register(AnchoredLayoutPlugin.class);
+        pluginManager.register(ModalViewPlugin.class);
+        pluginManager.register(HeaderBarPlugin.class);
+        pluginManager.register(AnimationPlugin.class);
+        pluginManager.register(ImageViewPlugin.class);
         pluginManager.register(DefaultLoaderPlugin.class);
         pluginManager.register(FourDotsLoaderPlugin.class);
 
-        pluginManager.register(DeviceNetworkPlugin.class);
-        pluginManager.register(AnimationPlugin.class);
-
-        pluginManager.register(AnchoredLayoutPlugin.class);
-        pluginManager.register(DrawerPlugin.class);
-        pluginManager.register(HeaderBarPlugin.class);
-        pluginManager.register(ModalViewPlugin.class);
-        pluginManager.register(ImageViewPlugin.class);
-
         // Create the initial worker.
-        worker = new AstroWorkerPlugin(this);
-        pluginManager.addPluginToInstanceList(worker);
+        worker = new AstroWorker(this);
 
         // Enable Cordova plugins by associating the worker's Cordova webview with the activity.
         CordovaWebView webView = (CordovaWebView)worker.getView();


### PR DESCRIPTION
Pass in plugin instead of pluging address to an rpc call which references another plugin by it's address

Status: **Opened for visibility**

Reviewers: @noahadams @jvaill @MikeKlemarewski @jansepar @jeremywiebe @dnerdy 
JIRA: https://mobify.atlassian.net/browse/HYB-238
Linked PRs: https://github.com/mobify/astro/pull/135
https://github.com/mobify/BTR-Astro/pull/10
https://github.com/mobify/astro-tutorial/pull/22
https://github.com/mobify/astro-scaffold/pull/6
## Changes
- Update app.js to remove .address from plugin method calls
## How to test-drive this PR
- Run the app with updated method calls in the plugins
## Research resources
- None
