### PR TITLE
Release 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-velo",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "Mobify",
   "dependencies": {
     "astro-sdk": "^0.7.0",


### PR DESCRIPTION
Update to point to Astro version that removes dependency on `grunt-harp`