### PR TITLE
HYB-809 Android manifest to use astro common application

### DIFF
--- a/android/velo/src/main/AndroidManifest.xml
+++ b/android/velo/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.mobify.astro.velo" >
 
     <application
+        android:name="com.mobify.astro.CommonApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name">


### PR DESCRIPTION
The recent Astro dialog manager change added a class which overrides `Application`. This needs to be defined in the `AndroidManifest`

JIRA: **[HYB-809 Modal views default background should be white](https://mobify.atlassian.net/browse/HYB-809)**
Linked PRs:
- [Astro](https://github.com/mobify/astro/pull/489)
- [Scaffold](https://github.com/mobify/astro-scaffold/pull/97)

## Changes
- Add `CommonApplication` as application name in `AndroidManifest`

## How to test-drive this PR
- The app should launch and modals should open and close

## TODOS:
~~- [ ] Update tutorial documentation in the `dev` folder (in the Astro repo) to match the modified tutorial.~~
~~- [ ] Preview the docs to make sure your changes look good (see [here](https://github.com/mobify/astro#documentation) for instructions on how to preview).~~

- [x] Change works in both Android and ~~iOS~~.
- [x] +1 from an engineer on the Astro team.

