### PR TITLE
MSG-355: Updating to build android pushclient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## To be released
+- Include pushclient module in android build
 
 ## v0.12.0
 - Updates for release v0.12.0 of Astro

--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -11,6 +11,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/velo" />
             <option value="$PROJECT_DIR$/../node_modules/astro-sdk/android" />
+            <option value="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient" />
           </set>
         </option>
         <option name="myModules">
@@ -18,6 +19,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/velo" />
             <option value="$PROJECT_DIR$/../node_modules/astro-sdk/android" />
+            <option value="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" assert-keyword="true" jdk-15="true" project-jdk-name="Android API 23 Platform" project-jdk-type="Android SDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="Android API 23 Platform" project-jdk-type="Android SDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
   <component name="masterDetails">

--- a/android/.idea/modules.xml
+++ b/android/.idea/modules.xml
@@ -5,6 +5,7 @@
       <module fileurl="file://$PROJECT_DIR$/android.iml" filepath="$PROJECT_DIR$/android.iml" />
       <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" />
       <module fileurl="file://$PROJECT_DIR$/../astro/android/astro.iml" filepath="$PROJECT_DIR$/../astro/android/astro.iml" />
+      <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" />
       <module fileurl="file://$PROJECT_DIR$/velo/velo.iml" filepath="$PROJECT_DIR$/velo/velo.iml" />
     </modules>
   </component>

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,3 @@
-include ':velo', ':astro'
+include ':velo', ':astro', ":astro:pushclient"
 project(':astro').projectDir = new File(settingsDir, '../node_modules/astro-sdk/android')
+project(':astro:pushclient').projectDir = new File(settingsDir, '../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient')

--- a/android/velo/velo.iml
+++ b/android/velo/velo.iml
@@ -64,14 +64,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -80,9 +72,16 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
@@ -109,9 +108,14 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="support-v4-23.1.1" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-23.1.1" level="project" />
+    <orderEntry type="library" exported="" name="moshi-1.1.0" level="project" />
+    <orderEntry type="library" exported="" name="support-v4-23.1.1" level="project" />
     <orderEntry type="library" exported="" name="appcompat-v7-23.1.1" level="project" />
+    <orderEntry type="library" exported="" name="okio-1.6.0" level="project" />
+    <orderEntry type="library" exported="" name="converter-moshi-2.0.2" level="project" />
+    <orderEntry type="library" exported="" name="okhttp-3.2.0" level="project" />
+    <orderEntry type="library" exported="" name="retrofit-2.0.2" level="project" />
     <orderEntry type="module" module-name="astro" exported="" />
   </component>
 </module>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "git+ssh://git@github.com:mobify/astro.git#msg-355-astro-implementation",
+    "astro-sdk": "git+ssh://git@github.com:mobify/astro.git#develop",
     "bluebird": "~2.9.24"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "^0.12.0",
+    "astro-sdk": "git+ssh://git@github.com:mobify/astro.git#msg-355-astro-implementation",
     "bluebird": "~2.9.24"
   },
   "devDependencies": {


### PR DESCRIPTION
The Android `pushclient` module must be included in `settings.gradle` file of the app in order for the app to compile.

JIRA: https://mobify.atlassian.net/browse/MSG-355
Linked PRs: None

## Changes
- Update `settings.gradle` to include `pushclient` module
- Point package.json at develop version of astro

## How to test-drive this PR
- Build the project in Android and install the app

## TODOS:
- [x] Update tutorial documentation in the `dev` folder (in the Astro repo) to match the modified tutorial.
- [x] Preview the docs to make sure your changes look good (see [here](https://github.com/mobify/astro#documentation) for instructions on how to preview).
- [x] Change works in both Android and iOS.
- [ ] +1 from an engineer on the Astro team.
- [x] Update the astro branch to point at develop once the astro changes have been merged

