### PR TITLE
Include the PushClient iOS library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## To be released
+- Include pushclient module in iOS build
 
 ## v0.13.0
 - Include pushclient module in android build

--- a/ios/velo.xcodeproj/project.pbxproj
+++ b/ios/velo.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		87C6A8E91B430E15001876CE /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 87C6A8D71B430E15001876CE /* config.xml */; };
 		87C6A8F61B430EDD001876CE /* www in Resources */ = {isa = PBXBuildFile; fileRef = 87C6A8F51B430EDD001876CE /* www */; };
 		96C2AD861B62B6180032A784 /* app.js in Resources */ = {isa = PBXBuildFile; fileRef = 87C6A8F91B430FB7001876CE /* app.js */; };
+		CB9EA0AD1D24628200E102D7 /* PushClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB9EA0AC1D24628200E102D7 /* PushClient.framework */; };
+		CB9EA0AE1D24628800E102D7 /* PushClient.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CB9EA0AC1D24628200E102D7 /* PushClient.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +41,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				CB9EA0AE1D24628800E102D7 /* PushClient.framework in Embed Frameworks */,
 				87132A211B6016FF00FC74A4 /* Astro.framework in Embed Frameworks */,
 				87132A231B6016FF00FC74A4 /* Cordova.framework in Embed Frameworks */,
 			);
@@ -64,6 +67,7 @@
 		87C6A8F51B430EDD001876CE /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; path = www; sourceTree = "<group>"; };
 		87C6A8F71B430FA2001876CE /* app.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = app.js; path = ../../app/app.js; sourceTree = "<group>"; };
 		87C6A8F91B430FB7001876CE /* app.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = app.js; path = ../../app/build/app.js; sourceTree = "<group>"; };
+		CB9EA0AC1D24628200E102D7 /* PushClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PushClient.framework; path = "$(CONFIGURATION_BUILD_DIR)/PushClient.framework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,6 +75,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB9EA0AD1D24628200E102D7 /* PushClient.framework in Frameworks */,
 				87132A201B6016FF00FC74A4 /* Astro.framework in Frameworks */,
 				87132A221B6016FF00FC74A4 /* Cordova.framework in Frameworks */,
 			);
@@ -89,6 +94,7 @@
 		87C6A87D1B43044D001876CE = {
 			isa = PBXGroup;
 			children = (
+				CB9EA0AC1D24628200E102D7 /* PushClient.framework */,
 				87132A1E1B6016FF00FC74A4 /* Astro.framework */,
 				87132A1F1B6016FF00FC74A4 /* Cordova.framework */,
 				87C6A8D61B430E15001876CE /* Cordova */,

--- a/ios/velo.xcworkspace/contents.xcworkspacedata
+++ b/ios/velo.xcworkspace/contents.xcworkspacedata
@@ -5,6 +5,9 @@
       location = "container:"
       name = "Astro">
       <FileRef
+         location = "group:../node_modules/astro-sdk/node_modules/mobify-push-ios-client/PushClient/PushClient.xcodeproj">
+      </FileRef>
+      <FileRef
          location = "group:../node_modules/astro-sdk/ios/Astro.xcodeproj">
       </FileRef>
       <FileRef

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "0.13.0",
+    "astro-sdk": "mobify/astro.git#develop",
     "bluebird": "~2.9.24"
   },
   "devDependencies": {


### PR DESCRIPTION
Include the PushClient iOS library

~~JIRA: **(link to JIRA ticket)**~~
Linked PRs: **mobify/astro/512**

## Changes
- Include the PushClient iOS library

## How to test-drive this PR
- If mobify/astro#512 has not been merged into astro develop yet, update your package.json to point to astro.git/#ios-push-integration
- Build the app for iOS

## TODOS:
~~- [ ] Update tutorial documentation in the `dev` folder (in the Astro repo) to match the modified tutorial.~~
~~- [ ] Preview the docs to make sure your changes look good (see [here](https://github.com/mobify/astro#documentation) for instructions on how to preview).~~
~~- [ ] Change works in both Android and iOS.~~
- [x] +1 from an engineer on the Astro team.
