### PR TITLE
[HYB-968]: Update android gradle with new astro config

### DIFF
--- a/android/velo/build.gradle
+++ b/android/velo/build.gradle
@@ -16,7 +16,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-        debug {}
     }
 }
 
@@ -29,6 +28,6 @@ preBuild.dependsOn buildJS
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.1'
-    releaseCompile project(path: ':astro', configuration: 'release')
-    debugCompile project(path: ':astro', configuration: 'debug')
+    releaseCompile project(path: ':astro', configuration: 'previewDisabledRelease')
+    debugCompile project(path: ':astro', configuration: 'previewDisabledDebug')
 }

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -4,7 +4,6 @@ set -e
 
 echo "Setting up path variables and finding node"
 MYPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-EXTRA_NPM_ARGS=""
 EXTRA_GRUNT_ARGS=""
 
 function findNode() {
@@ -12,7 +11,6 @@ function findNode() {
 }
 
 if [ "$1" == "--no-color" ]; then
-    EXTRA_NPM_ARGS="--no-color $EXTRA_NPM_ARGS"
     EXTRA_GRUNT_ARGS="--no-color $EXTRA_GRUNT_ARGS"
 fi
 

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -2,9 +2,9 @@
 
 set -e
 
+echo "Setting up path variables and finding node"
 MYPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-ROOT=$MYPATH/..
-EXTRA_NPM_ARGS="--no-progress --no-spin"
+EXTRA_NPM_ARGS=""
 EXTRA_GRUNT_ARGS=""
 
 function findNode() {
@@ -15,11 +15,6 @@ if [ "$1" == "--no-color" ]; then
     EXTRA_NPM_ARGS="--no-color $EXTRA_NPM_ARGS"
     EXTRA_GRUNT_ARGS="--no-color $EXTRA_GRUNT_ARGS"
 fi
-
-pushd "$MYPATH"
-
-# Force supporting Homebrew installations of npm.
-export PATH=$PATH:/usr/local/bin
 
 if ! findNode; then
     echo "Cannot find 'npm'. Trying via nvm..."
@@ -39,20 +34,17 @@ if ! findNode; then
     fi
 fi
 
-if ! findNode; then
-    # Force supporting Homebrew installations of npm.
-    export PATH=$PATH:/usr/local/bin
-fi
+# Force supporting Homebrew installations of npm.
+export PATH=$PATH:/usr/local/bin
 
 if ! findNode; then
     echo "Cannot find 'npm'. Aborting. Add your npm path to \`user-env.sh\` and retry."
     exit 1
 fi
 
-# Build app.js.
-pushd $ROOT
-npm install $EXTRA_NPM_ARGS
-
+echo "Building app.js"
 pushd $MYPATH
-$MYPATH/node_modules/grunt-cli/bin/grunt $EXTRA_GRUNT_ARGS build
+    $MYPATH/node_modules/.bin/grunt $EXTRA_GRUNT_ARGS build
 popd
+
+echo "SUCCESS: build app.js"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "mobify/astro.git#release-v0.17.6",
+    "astro-sdk": "~0.17.0",
     "bluebird": "~2.9.24"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "0.17.3",
+    "astro-sdk": "mobify/astro.git#release-v0.17.6",
     "bluebird": "~2.9.24"
   },
   "devDependencies": {


### PR DESCRIPTION
Android will only use astro configurations with preview disabled
Update build-js.sh to be the same as scaffold

JIRA: https://mobify.atlassian.net/browse/HYB-968
Linked PRs: https://github.com/mobify/astro/pull/714

## Changes
- Update to version 0.17.6 version of astro
- debug and release builds now use preview disabled versions of astro
- build-js wasn't working correctly for me (I think the npm install was moving around astro dependencies when run). I upgraded to version in scaffold and it seems to work fine for me now.

## How to test-drive this PR
- Run Android app and ensure in compiles and runs
- Run iOS app to ensure no changes were needed

## TODOS:
- [x] Update tutorial documentation in the `dev` folder (in the Astro repo) to match the modified tutorial.
- [x] Preview the docs to make sure your changes look good (see [here](https://github.com/mobify/astro#documentation) for instructions on how to preview).
- [x] Change works in both Android and iOS.
- [ ] +1 from an engineer on the Astro team.

